### PR TITLE
Fix: Bug: User should be able to click on a task on the task index and go to the task's page

### DIFF
--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -6,10 +6,7 @@
 
 <div id="tasks">
   <% @tasks.each do |task| %>
-    <%= render task %>
-    <p>
-      <%= link_to "Show this task", task %>
-    </p>
+    <%= link_to task.title, task_path(task) %><br>
   <% end %>
 </div>
 

--- a/test/system/tasks_test.rb
+++ b/test/system/tasks_test.rb
@@ -34,6 +34,13 @@ class TasksTest < ApplicationSystemTestCase
     click_on "Back"
   end
 
+  test "clicking a task on the index page redirects to the show page" do
+    task = Task.create(title: "Test Task", completed: false)
+    visit tasks_url
+    click_link task.title
+    assert_current_path task_path(task)
+  end
+
   test "should destroy Task" do
     visit task_url(@task)
     click_on "Destroy this task", match: :first


### PR DESCRIPTION
Fixed by Aider model: gemini/gemini-2.0-flash